### PR TITLE
fix gmp library linking error in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ compile: ssss-split ssss-combine
 doc: ssss.1 ssss.1.html
 
 ssss-split: ssss.c
-	$(CC) -W -Wall -O2 -lgmp -o ssss-split ssss.c
+	$(CC) -W -Wall -O2 -o ssss-split ssss.c -lgmp
 	strip ssss-split
 
 ssss-combine: ssss-split


### PR DESCRIPTION
Best to use -l option later than source code. It handles 'undefined reference' errors.