### PR TITLE
Fix false positive error in memory lock success and compile warnings 

### DIFF
--- a/ssss.c
+++ b/ssss.c
@@ -178,7 +178,7 @@ void field_print(FILE* stream, const mpz_t x, int hexmode)
     size_t t;
     unsigned int i;
     int printable, warn = 0;
-    memset(buf, degree / 8 + 1, 0);
+    memset(buf, 0, degree / 8 + 1);
     mpz_export(buf, &t, 1, 1, 0, 0, x);
     for(i = 0; i < t; i++) {
       printable = (buf[i] >= 32) && (buf[i] < 127);

--- a/ssss.c
+++ b/ssss.c
@@ -561,6 +561,7 @@ int main(int argc, char *argv[])
 #if ! NOMLOCK
   int failedMemoryLock = 0;
   if (mlockall(MCL_CURRENT | MCL_FUTURE) < 0)
+  {
     failedMemoryLock = 1;
     switch(errno) {
     case ENOMEM:
@@ -576,6 +577,7 @@ int main(int argc, char *argv[])
       warning("couldn't get memory lock");
       break;
     }
+  }
 #endif
 
   if (getuid() != geteuid())


### PR DESCRIPTION
In my environment use gcc 6.1.0, ```make compile``` is warned. This PR is fix this.

- Line 181: -Wmemset-transposed-args
  - This warning is caused by wrong usage.
  - ```void *memset(void *s, int c, size_t n);```
  - this uninitialize buffer is overwrite by ```mpz_export()``` in line 182, this warn is not effected anything.
- Line 563,565 -Wmisleading-indentation
  - condintion bug?
  - Line 565: ```switch(error){...}``` run in memory lock success.
     - match default condition in switch.
     - Line 577: notify memory lock failure message in memory lock success.

```
root@bb59dbe42464:/ssss# gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/local/libexec/gcc/x86_64-pc-linux-gnu/6.1.0/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: /usr/src/gcc/configure --disable-multilib --enable-languages=c,c++,go
Thread model: posix
gcc version 6.1.0 (GCC)
root@bb59dbe42464:/ssss# make compile
cc -W -Wall -O2 -o ssss-split ssss.c -lgmp
ssss.c: In function 'field_print':
ssss.c:181:5: warning: 'memset' used with constant zero length parameter; this could be due to transposed parameters [-Wmemset-transposed-args]
     memset(buf, degree / 8 + 1, 0);
     ^~~~~~
ssss.c: In function 'main':
ssss.c:563:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
   if (mlockall(MCL_CURRENT | MCL_FUTURE) < 0)
   ^~
ssss.c:565:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     switch(errno) {
     ^~~~~~
strip ssss-split
ln -f ssss-split ssss-combine
```