### PR TITLE
Fix missing field init when security option is set

### DIFF
--- a/ssss.c
+++ b/ssss.c
@@ -524,14 +524,14 @@ enum ssss_errcode ask_secret(mpz_t secret)
       if (ec == ssss_ec_ok) {
         if (! opt_quiet)
           fprintf(stderr, "Using a %d bit security level.\n", opt_security);
-        field_init(opt_security);
       }
     }
   }
 
-  if (ec == ssss_ec_ok)
+  if (ec == ssss_ec_ok) {
+    field_init(opt_security);
     ec = field_import(secret, buf, opt_hex);
-  else
+  } else
     mpz_clear(secret);
 
   if (ec == ssss_ec_ok)


### PR DESCRIPTION
Commit [7666310](https://github.com/MrJoy/ssss/commit/7666310114178963902a0899e36fad1d38c96d13) introduced the following bug: `field_init()` is called only if security option is not set in the `ask_secret()` function.

As a result, setting the security option (eg.: `ssss-split -t 2 -n 2 -s 1024`) systematically generates an "input string too long" fatal error.